### PR TITLE
Improve detection of errors when calling generic methods from a static function

### DIFF
--- a/src/Boo.Lang.Compiler/Steps/ProcessMethodBodies.cs
+++ b/src/Boo.Lang.Compiler/Steps/ProcessMethodBodies.cs
@@ -1946,6 +1946,8 @@ namespace Boo.Lang.Compiler.Steps
 
 			if (!(node.Target is MemberReferenceExpression)) //no self.
 				node.Target = CodeBuilder.MemberReferenceForEntity(CreateSelfReference(), entity);
+			if (TypeSystemServices.IsError(node.Target))
+				Error(node);
 		}
 
 		override public void OnReferenceExpression(ReferenceExpression node)
@@ -5344,6 +5346,8 @@ namespace Boo.Lang.Compiler.Steps
 		bool AssertTargetContext(Expression targetContext, IMember member)
 		{
 			if (member.IsStatic) return true;
+			if (NodeType.GenericReferenceExpression == targetContext.NodeType)
+				targetContext = ((GenericReferenceExpression)targetContext).Target;
 			if (NodeType.MemberReferenceExpression != targetContext.NodeType) return true;
 
 			Expression targetReference = ((MemberReferenceExpression)targetContext).Target;

--- a/tests/BooCompiler.Tests/CompilerErrorsTestFixture.cs
+++ b/tests/BooCompiler.Tests/CompilerErrorsTestFixture.cs
@@ -135,6 +135,12 @@ namespace BooCompiler.Tests
 		}
 		
 		[Test]
+		public void BCE0020_4()
+		{
+			RunCompilerTestCase(@"BCE0020-4.boo");
+		}
+		
+		[Test]
 		public void BCE0021_1()
 		{
 			RunCompilerTestCase(@"BCE0021-1.boo");

--- a/tests/testcases/errors/BCE0020-4.boo
+++ b/tests/testcases/errors/BCE0020-4.boo
@@ -1,0 +1,13 @@
+"""
+BCE0020-4.boo(11,9): BCE0020: An instance of type 'Foo' is required to access non static member 'go'.
+BCE0020-4.boo(12,9): BCE0020: An instance of type 'Foo' is required to access non static member 'go2'.
+"""
+class Foo:
+	def go [of T]():
+		return
+	def go2(param as int):
+		return param
+	static def fail():
+	 	go[of int]()
+	 	go2(0)
+


### PR DESCRIPTION
Calling a generic member method from a static method did not always generate an error. There are two places which can detect the error, one of them could detect the error the other could not. 

When extending a class from another assembly the path that could detect the error was not taken, which could lead to invalid assemblies causing runtime crashes.

With this change both paths can detect the error and the error is propagated one level to avoid duplicate errors.
